### PR TITLE
Adds every config option from Leaflet

### DIFF
--- a/src/core_plugins/tests_bundle/tests_entry_template.js
+++ b/src/core_plugins/tests_bundle/tests_entry_template.js
@@ -30,10 +30,11 @@ window.__KBN__ = {
     esRequestTimeout: '300000',
     tilemap: {
       url: 'https://tiles.elastic.co/v1/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana',
-      subdomains: [],
-      minZoom: 1,
-      maxZoom: 8,
-      attribution: '© [Elastic Tile Service](https://www.elastic.co/elastic_tile_service_tos)'
+      options: {
+        minZoom: 0,
+        maxZoom: 8,
+        attribution: '© [Elastic Tile Service](https://www.elastic.co/elastic_tile_service_tos)'
+      }
     }
   },
   uiSettings: {

--- a/src/server/config/schema.js
+++ b/src/server/config/schema.js
@@ -134,10 +134,35 @@ module.exports = () => Joi.object({
 
   tilemap: Joi.object({
     url: Joi.string().default('https://tiles.elastic.co/v1/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana'),
-    subdomains: Joi.array().items(Joi.string()).default([]),
-    minZoom: Joi.number().default(1),
-    maxZoom: Joi.number().default(8),
-    attribution: Joi.string().default('© [Elastic Tile Service](https://www.elastic.co/elastic_tile_service_tos)')
+    options: Joi.object({
+      attribution: Joi.string().default('© [Elastic Tile Service](https://www.elastic.co/elastic_tile_service_tos)'),
+      minZoom: Joi.number().default(0),
+      maxZoom: Joi.number().default(8),
+      maxNativeZoom: Joi.number().optional(),
+      tileSize: Joi.number().optional(),
+      subdomains: Joi.array().items(Joi.string()).single().optional(),
+      errorTileUrl: Joi.string().uri().optional(),
+      tms: Joi.boolean().optional(),
+      continuousWorld: Joi.boolean().optional(),
+      noWrap: Joi.boolean().optional(),
+      zoomOffset: Joi.number().optional(),
+      zoomReverse: Joi.boolean().optional(),
+      opacity: Joi.number().optional(),
+      zIndex: Joi.number().optional(),
+      unloadInvisibleTiles: Joi.boolean().optional(),
+      detectRetina: Joi.boolean().optional(),
+      reuseTiles: Joi.boolean().optional(),
+      bounds: Joi.object({
+        southWest: Joi.object({
+          lat: Joi.number().required(),
+          lng: Joi.number().required()
+        }).required(),
+        northEast: Joi.object({
+          lat: Joi.number().required(),
+          lng: Joi.number().required()
+        }).required()
+      }).optional()
+    }).default()
   }).default(),
 
 }).default();

--- a/src/ui/public/vislib/visualizations/_map.js
+++ b/src/ui/public/vislib/visualizations/_map.js
@@ -17,12 +17,13 @@ export default function MapFactory(Private, tilemap) {
   let defaultMapCenter = [15, 5];
   let defaultMarkerType = 'Scaled Circle Markers';
 
+  let tilemapOptions = tilemap.options;
+
+  tilemapOptions.attribution = marked(tilemapOptions.attribution);
+
   let mapTiles = {
     url: tilemap.url,
-    options: {
-      attribution: marked(tilemap.attribution),
-      subdomains: tilemap.subdomains
-    }
+    options: tilemapOptions 
   };
 
   let markerTypes = {
@@ -56,11 +57,10 @@ export default function MapFactory(Private, tilemap) {
     this._attr = params.attr || {};
 
     let mapOptions = {
-      minZoom: tilemap.minZoom,
-      maxZoom: tilemap.maxZoom,
+      minZoom: tilemapOptions.minZoom,
+      maxZoom: tilemapOptions.maxZoom,
       noWrap: true,
       maxBounds: L.latLngBounds([-90, -220], [90, 220]),
-      scrollWheelZoom: false,
       fadeAnimation: false,
     };
 


### PR DESCRIPTION
This changes the configuration in the existing PR by adding every Leaflet option.

It also nests every tilemap option under `options` rather than as peer settings of `url`.
