### PR TITLE
Ensure image buffers passed to the worker spun to generate a PDF request is transferrable

### DIFF
--- a/x-pack/platform/plugins/shared/screenshotting/server/formats/pdf/pdf_maker/pdfmaker.ts
+++ b/x-pack/platform/plugins/shared/screenshotting/server/formats/pdf/pdf_maker/pdfmaker.ts
@@ -140,18 +140,24 @@ export class PdfMaker {
     image: Buffer,
     opts: { title?: string; description?: string } = { title: '', description: '' }
   ) {
-    this.logger.debug(`Adding image to PDF. Image size: ${image.byteLength}`); // prettier-ignore
+    // Convert the image buffer to a transferable buffer.
+    // See https://github.com/nodejs/node/issues/55593 for the rationale behind this decision.
+    const _transferableImage = new ArrayBuffer(image.byteLength);
+    new Uint8Array(_transferableImage).set(new Uint8Array(image));
+
+    this.logger.debug(`Adding image to PDF. Image size: ${_transferableImage.byteLength}`); // prettier-ignore
     const size = this.layout.getPdfImageSize();
     const img = {
       // The typings are incomplete for the image property.
       // It's possible to pass a Buffer as the image data.
       // @see https://github.com/bpampuch/pdfmake/blob/0.2/src/printer.js#L654
-      image,
+      image: _transferableImage,
       alignment: 'center' as 'center',
       height: size.height,
       width: size.width,
     } as unknown as ContentImage;
-    this.transferList.push(image.buffer);
+
+    this.transferList.push(_transferableImage);
 
     if (this.layout.useReportingBranding) {
       return this.addBrandedImage(img, opts);
@@ -254,16 +260,8 @@ export class PdfMaker {
         const generatePdfRequest: GeneratePdfRequest = {
           data: this.getGeneratePdfRequestData(),
         };
-        try {
-          myPort.postMessage(generatePdfRequest, this.transferList);
-        } catch (e) {
-          // See https://github.com/nodejs/node/issues/55593
-          if (e.name === 'DataCloneError') {
-            myPort.postMessage(generatePdfRequest);
-          } else {
-            throw e;
-          }
-        }
+
+        myPort.postMessage(generatePdfRequest, this.transferList);
       });
     } finally {
       await this.cleanupWorker();


### PR DESCRIPTION
## Summary

Modify implementation to add image to pdf creates new transferrable image buffer, so that buffers that get sent to reporting worker will always get detached and free up memory on the main thread.

Informed from https://github.com/elastic/kibana/pull/205983/files#r1929384942

<!--

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

-->